### PR TITLE
Force apache2 version to prevent CVE-2021-41773

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -18,9 +18,9 @@ RUN mkdir ${BUILD_DIR}
 
 # add dependencies, build and install mod_auth_openidc, need atomic operation for image size
 RUN apk update && apk add --no-cache \
-  apache2 \
-  apache2-proxy \
-  apache2-ssl \
+  apache2=2.4.50-r0 \
+  apache2-proxy=2.4.50-r0 \
+  apache2-ssl=2.4.50-r0 \
   wget \
   jansson \
   hiredis \

--- a/Dockerfile
+++ b/Dockerfile
@@ -18,9 +18,9 @@ RUN mkdir ${BUILD_DIR}
 
 # add dependencies, build and install mod_auth_openidc, need atomic operation for image size
 RUN apk update && apk add --no-cache \
-  apache2=2.4.50-r0 \
-  apache2-proxy=2.4.50-r0 \
-  apache2-ssl=2.4.50-r0 \
+  apache2=2.4.51-r0 \
+  apache2-proxy=2.4.51-r0 \
+  apache2-ssl=2.4.51-r0 \
   wget \
   jansson \
   hiredis \


### PR DESCRIPTION
See: https://httpd.apache.org/security/vulnerabilities_24.html